### PR TITLE
Update to latest openwhisk/dockerskeleton

### DIFF
--- a/dockerSkeleton/Dockerfile
+++ b/dockerSkeleton/Dockerfile
@@ -1,33 +1,12 @@
-#
-# Dockerfile for building a blackbox container with a nodejs server interfacing to a client binary.
-#
-FROM buildpack-deps:trusty-curl
+# Dockerfile for example whisk docker action
+FROM openwhisk/dockerskeleton
+ 
+ENV FLASK_PROXY_PORT 8080
 
-ENV DEBIAN_FRONTEND noninteractive
+### Add source file(s)
+RUN apk update
+RUN apk add aspell-en aspell
+RUN rm -f /action/exec
+ADD action.sh /action/exec
 
-# based on https://github.com/nodejs/docker-node
-ENV NODE_VERSION 0.12.14
-RUN curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.gz" \
-  && tar -xzf "node-v$NODE_VERSION-linux-x64.tar.gz" -C /usr/local --strip-components=1 \
-  && rm "node-v$NODE_VERSION-linux-x64.tar.gz"
-
-# Get gcc
-RUN apt-get update --fix-missing && \
-apt-get -y install gcc
-
-RUN mkdir /logs
-
-ADD ./client /blackbox/client
-ADD ./server /blackbox/server
-
-RUN cd /blackbox/server; rm -rf node_modules logs
-RUN cd /blackbox/server; npm install . 
-
-RUN apt-get install -y aspell
-RUN rm -f /blackbox/client/action
-ADD action.sh /blackbox/client/action
-
-# Final steps
-RUN chmod uog+x /blackbox/client/action
-EXPOSE 8080
-CMD ["/bin/bash", "-c", "cd blackbox/server && node ./app.js"]
+CMD ["/bin/bash", "-c", "cd actionProxy && python -u actionproxy.py"]

--- a/dockerSkeleton/action.sh
+++ b/dockerSkeleton/action.sh
@@ -12,7 +12,7 @@ FILE=/tmp/output.txt
 # then decode it from base64 format, and dump the result to a file.
 echo $1 | sed -e 's/b64.://g' \
         | tr -d '"' | tr -d ' ' | tr -d '}' | tr -d '{' \
-        | base64 --decode >& $FILE
+        | base64 -d >& $FILE
 
 # Pipe the input file to aspell, and then format the result on one line with
 # spaces as delimiters


### PR DESCRIPTION
The openwhisk/dockerskeleton has been updated since the time of your article https://developer.ibm.com/openwhisk/2016/06/17/spellcheck-openwhisk-docker/

Also I had to modify the action.sh script since base64 on Alpine does not take --decode to -d